### PR TITLE
Fix bug in updating widget after data change

### DIFF
--- a/inst/htmlwidgets/lib/cal-heatmap/cal-heatmap.js
+++ b/inst/htmlwidgets/lib/cal-heatmap/cal-heatmap.js
@@ -3339,7 +3339,7 @@ Legend.prototype.buildColors = function() {
 		_legend.unshift(_legend[0] - (_legend[_legend.length-1] - _legend[0])/_legend.length);
 	}
 
-	var colorScale = d3.scale.linear()
+	var colorScale = d3.scale.sqrt()
 		.range(_colorRange)
 		.interpolate(d3.interpolateHsl)
 		.domain([d3.min(_legend), d3.max(_legend)])

--- a/inst/htmlwidgets/lib/cal-heatmap/cal-heatmap.js
+++ b/inst/htmlwidgets/lib/cal-heatmap/cal-heatmap.js
@@ -3341,7 +3341,7 @@ Legend.prototype.buildColors = function() {
 
 	var colorScale = d3.scale.linear()
 		.range(_colorRange)
-		.interpolate(d3.interpolateHcl)
+		.interpolate(d3.interpolateHsl)
 		.domain([d3.min(_legend), d3.max(_legend)])
 	;
 

--- a/inst/htmlwidgets/lib/cal-heatmap/cal-heatmap.js
+++ b/inst/htmlwidgets/lib/cal-heatmap/cal-heatmap.js
@@ -3339,7 +3339,7 @@ Legend.prototype.buildColors = function() {
 		_legend.unshift(_legend[0] - (_legend[_legend.length-1] - _legend[0])/_legend.length);
 	}
 
-	var colorScale = d3.scale.sqrt()
+	var colorScale = d3.scale.log()
 		.range(_colorRange)
 		.interpolate(d3.interpolateHsl)
 		.domain([d3.min(_legend), d3.max(_legend)])

--- a/inst/htmlwidgets/supercaliheatmapwidget.js
+++ b/inst/htmlwidgets/supercaliheatmapwidget.js
@@ -12,6 +12,9 @@ HTMLWidgets.widget({
 
       renderValue: function(x) {
 
+        while (document.getElementById(el.id).hasChildNodes()) {
+            document.getElementById(el.id).removeChild(document.getElementById(el.id).lastChild);
+        }
         // console.log(x);
 
         fmt = d3.time.format("%Y-%m-%d");


### PR DESCRIPTION
When the render function is called again, the new widget appears on top of the old widget (the old one is not removed). Added two lines fix it. This can be helpful in using the package in the Shiny. 